### PR TITLE
Kubernetes networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,52 @@ yes
 
 no
 
+kubernetes-networks
+-
+#### Run kubernetes-networks
+
+`kubectl apply -f kubernetes-networks/web-deploy.yaml`
+
+`kubectl apply -f kubernetes-networks/web-svc-cip.yaml -f kubernetes-networks/web-svc-lb.yaml -f kubernetes-networks/web-svc-headless.yaml`
+
+`kubectl apply -f kubernetes-networks/web-ingress.yaml`
+
+Со *
+
+`kubectl apply -f kubernetes-networks/coredns/`
+
+`kubectl apply -f kubernetes-networks/dashboard/`
+
+`kubectl apply -f kubernetes-networks/canary/app-v1.yaml -f kubernetes-networks/canary/ingress-v1.yaml`
+
+`kubectl apply -f kubernetes-networks/canary/app-v2.yaml`
+
+`kubectl apply -f kubernetes-networks/canary/ingress-v2-canary.yaml`
+
+#### Expose kubernetes-networks
+
+В зависимости от последовательности развертывания LB сервиса nginx-ingress и web-svc-lb используемые IP адреса могут отличаться. Для проверки IP адреса можно выполнить следующие команды:
+
+`kubectl get svc`
+
+`kubectl get svc -n ingress-nginx `
+
+#### Explore kubernetes-networks
+
+После того, как узнали IP адрес балансировщика ingress и сервиса web-svc-lb, проверяем наши сервисы:
+
+http://172.17.255.*
+
+http://172.17.255.*/web
+
+Со *
+
+nslookup web-svc-cip.default.svc.cluster.local 172.17.255.10
+
+https://172.17.255.*/dashboard
+
+while sleep 0.1; do curl 172.17.255.* -H "Host: my-app.com"; done
+
 
 | HW Dashboard                                                                                                         |
 | :----------------------------------------------------------------------------------------------------------------------------------- |

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -21,7 +21,7 @@ spec:
       readinessProbe:
         initialDelaySeconds: 10
         httpGet:
-          path: "/_healthz"
+          path: "/index.html"
           port: 8000
       livenessProbe:
         initialDelaySeconds: 10

--- a/kubernetes-networks/canary/app-v1.yaml
+++ b/kubernetes-networks/canary/app-v1.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-app-v1
+  labels:
+    app: my-app
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+  selector:
+    app: my-app
+    version: v1.0.0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app-v1
+  labels:
+    app: my-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-app
+      version: v1.0.0
+  template:
+    metadata:
+      labels:
+        app: my-app
+        version: v1.0.0
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9101"
+    spec:
+      containers:
+      - name: my-app
+        image: containersol/k8s-deployment-strategies
+        ports:
+        - name: http
+          containerPort: 8080
+        - name: probe
+          containerPort: 8086
+        env:
+        - name: VERSION
+          value: v1.0.0
+        livenessProbe:
+          httpGet:
+            path: /live
+            port: probe
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: probe
+          periodSeconds: 5

--- a/kubernetes-networks/canary/app-v2.yaml
+++ b/kubernetes-networks/canary/app-v2.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-app-v2
+  labels:
+    app: my-app
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+  selector:
+    app: my-app
+    version: v2.0.0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app-v2
+  labels:
+    app: my-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-app
+      version: v2.0.0
+  template:
+    metadata:
+      labels:
+        app: my-app
+        version: v2.0.0
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9101"
+    spec:
+      containers:
+      - name: my-app
+        image: containersol/k8s-deployment-strategies
+        ports:
+        - name: http
+          containerPort: 8080
+        - name: probe
+          containerPort: 8086
+        env:
+        - name: VERSION
+          value: v2.0.0
+        livenessProbe:
+          httpGet:
+            path: /live
+            port: probe
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: probe
+          periodSeconds: 5

--- a/kubernetes-networks/canary/ingress-v1.yaml
+++ b/kubernetes-networks/canary/ingress-v1.yaml
@@ -1,0 +1,16 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: my-app
+  labels:
+    app: my-app
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  rules:
+  - host: my-app.com
+    http:
+      paths:
+      - backend:
+          serviceName: my-app-v1
+          servicePort: 80

--- a/kubernetes-networks/canary/ingress-v2-canary.yaml
+++ b/kubernetes-networks/canary/ingress-v2-canary.yaml
@@ -1,0 +1,20 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: my-app-canary
+  labels:
+    app: my-app
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+
+    # Enable canary and send 10% of traffic to version 2
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-weight: "50"
+spec:
+  rules:
+  - host: my-app.com
+    http:
+      paths:
+      - backend:
+          serviceName: my-app-v2
+          servicePort: 80

--- a/kubernetes-networks/canary/ingress-v2.yaml
+++ b/kubernetes-networks/canary/ingress-v2.yaml
@@ -1,0 +1,16 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: my-app
+  labels:
+    app: my-app
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  rules:
+  - host: my-app.com
+    http:
+      paths:
+      - backend:
+          serviceName: my-app-v2
+          servicePort: 80

--- a/kubernetes-networks/coredns/dns-svc-tcp.yaml
+++ b/kubernetes-networks/coredns/dns-svc-tcp.yaml
@@ -1,0 +1,16 @@
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: dns-svc-tcp
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: dns
+spec:
+  loadBalancerIP: 172.17.255.10
+  selector:
+    k8s-app: kube-dns
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 53

--- a/kubernetes-networks/coredns/dns-svc-udp.yaml
+++ b/kubernetes-networks/coredns/dns-svc-udp.yaml
@@ -1,0 +1,16 @@
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: dns-svc-udp
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: dns
+spec:
+  loadBalancerIP: 172.17.255.10
+  selector:
+    k8s-app: kube-dns
+  type: LoadBalancer
+  ports:
+    - protocol: UDP
+      port: 53

--- a/kubernetes-networks/dashboard/dashboard-ingress.yaml
+++ b/kubernetes-networks/dashboard/dashboard-ingress.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: kubernetes-dashboard
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/add-base-url: "true"
+    #nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    #nginx.ingress.kubernetes.io/use-regex: "true"
 spec:
   rules:
     - http:

--- a/kubernetes-networks/dashboard/dashboard-ingress.yaml
+++ b/kubernetes-networks/dashboard/dashboard-ingress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: dashboard
+  namespace: kubernetes-dashboard
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /dashboard
+            backend:
+              serviceName: kubernetes-dashboard
+              servicePort: 80

--- a/kubernetes-networks/dashboard/dashboard-ingress.yaml
+++ b/kubernetes-networks/dashboard/dashboard-ingress.yaml
@@ -4,15 +4,15 @@ metadata:
   name: dashboard
   namespace: kubernetes-dashboard
   annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /
-    nginx.ingress.kubernetes.io/add-base-url: "true"
-    #nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-    #nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      rewrite ^(/dashboard)$ $1/ permanent;
+      rewrite "(?i)/dashboard(/|$)(.*)" /$2 break;
 spec:
   rules:
     - http:
         paths:
-          - path: /dashboard
+          - path: /dashboard(/|$)(.*)
             backend:
               serviceName: kubernetes-dashboard
-              servicePort: 80
+              servicePort: 443

--- a/kubernetes-networks/dashboard/dashboard-ingress.yaml
+++ b/kubernetes-networks/dashboard/dashboard-ingress.yaml
@@ -5,9 +5,7 @@ metadata:
   namespace: kubernetes-dashboard
   annotations:
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      rewrite ^(/dashboard)$ $1/ permanent;
-      rewrite "(?i)/dashboard(/|$)(.*)" /$2 break;
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   rules:
     - http:

--- a/kubernetes-networks/metallb-config.yaml
+++ b/kubernetes-networks/metallb-config.yaml
@@ -1,0 +1,13 @@
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - 172.17.255.1-172.17.255.255

--- a/kubernetes-networks/nginx-lb.yaml
+++ b/kubernetes-networks/nginx-lb.yaml
@@ -1,0 +1,21 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+    - name: https
+      port: 443
+      targetPort: https

--- a/kubernetes-networks/web-deploy.yaml
+++ b/kubernetes-networks/web-deploy.yaml
@@ -1,9 +1,9 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: webapp
+  name: web
   labels:
-    app: webapp
+    app: web
 spec:
   replicas: 3
   selector:
@@ -39,8 +39,7 @@ spec:
               port: 8000
           livenessProbe:
             initialDelaySeconds: 10
-            httpGet:
-              path: "/_healthz"
+            tcpSocket:
               port: 8000
       volumes:
         - name: app

--- a/kubernetes-networks/web-deploy.yaml
+++ b/kubernetes-networks/web-deploy.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: webapp
+  labels:
+    app: webapp
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      initContainers:
+        - name: init
+          image: busybox:1.31.0
+          command: ['sh', '-c', 'wget -O- https://raw.githubusercontent.com/express42/otus-platform-snippets/master/Module-02/Introduction-to-Kubernetes/wget.sh | sh']
+          volumeMounts:
+            - mountPath: /app
+              name: app
+      containers:
+        - name: web
+          image: wbe7/webapp:1.5
+          volumeMounts:
+            - mountPath: /app
+              name: app
+          readinessProbe:
+            initialDelaySeconds: 10
+            httpGet:
+              path: "/index.html"
+              port: 8000
+          livenessProbe:
+            initialDelaySeconds: 10
+            httpGet:
+              path: "/_healthz"
+              port: 8000
+      volumes:
+        - name: app
+          emptyDir: {}

--- a/kubernetes-networks/web-ingress.yaml
+++ b/kubernetes-networks/web-ingress.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: web
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /web
+            backend:
+              serviceName: web-svc
+              servicePort: 8000

--- a/kubernetes-networks/web-svc-cip.yaml
+++ b/kubernetes-networks/web-svc-cip.yaml
@@ -1,0 +1,13 @@
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-cip
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-headless.yaml
+++ b/kubernetes-networks/web-svc-headless.yaml
@@ -1,0 +1,14 @@
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-lb.yaml
+++ b/kubernetes-networks/web-svc-lb.yaml
@@ -1,0 +1,13 @@
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-lb
+spec:
+  selector:
+    app: web
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000


### PR DESCRIPTION
# Выполнено ДЗ №

 - [x] Основное ДЗ
 - [x] Задания со *

## В процессе сделано:
 - Поправлены проверки для web-deploy
 - Добавлены разные виды сервисов для приложения
 - Включен режим балансировки IPVS
 - Установлен MetalLB
 - Установлен Ingress Controller с endpoint типа LB
 - Написан сервис LB для CoreDNS
 - Написан ingress для kubernetes-dashboard
 - Подготовлен пример канареечного развертывания c делением трафика между разными версиями приложения

## Как запустить проект:

`kubectl apply -f kubernetes-networks/web-deploy.yaml`

`kubectl apply -f kubernetes-networks/web-svc-cip.yaml -f kubernetes-networks/web-svc-lb.yaml -f kubernetes-networks/web-svc-headless.yaml`

`kubectl apply -f kubernetes-networks/web-ingress.yaml`

Со *

`kubectl apply -f kubernetes-networks/coredns/`

`kubectl apply -f kubernetes-networks/dashboard/`

`kubectl apply -f kubernetes-networks/canary/app-v1.yaml -f kubernetes-networks/canary/ingress-v1.yaml`

`kubectl apply -f kubernetes-networks/canary/app-v2.yaml`

`kubectl apply -f kubernetes-networks/canary/ingress-v2-canary.yaml`

## Как проверить работоспособность:

В зависимости от последовательности развертывания LB сервиса nginx-ingress и web-svc-lb используемые IP адреса могут отличаться. Для проверки IP адреса можно выполнить следующие команды:

`kubectl get svc`

`kubectl get svc -n ingress-nginx `

После того, как узнали IP адрес балансировщика ingress и сервиса web-svc-lb, проверяем наши сервисы:

http://172.17.255.*

http://172.17.255.*/web

Со *

`nslookup web-svc-cip.default.svc.cluster.local 172.17.255.10`

https://172.17.255.*/dashboard

`while sleep 0.1; do curl 172.17.255.* -H "Host: my-app.com"; done`

## PR checklist:
 - [x] Выставлен label с номером домашнего задания
